### PR TITLE
feat: Add docker ls format options

### DIFF
--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -167,7 +167,8 @@ function! s:dt_ui_load() abort
 		let b:first_row += 1
 	endif
 
-	silent! execute printf("read ! %s%s %s ls %s %s",s:sudo_mode(),g:dockertools_docker_cmd,g:dockertools_managers[s:manager_position],['','-a'][b:show_all_containers&&s:manager_position!=2&&s:manager_position!=-1], s:dockertools_ls_filter)
+	let l:manager = g:dockertools_managers[s:manager_position]
+	silent! execute printf("read ! %s%s %s ls %s %s %s",s:sudo_mode(),g:dockertools_docker_cmd,l:manager,['','-a'][b:show_all_containers&&s:manager_position!=2&&s:manager_position!=-1], s:dockertools_ls_filter, s:dt_set_format(l:manager))
 
 	silent 1d
 	call setpos('.', l:save_cursor)
@@ -223,6 +224,13 @@ function! s:dt_set_filter(filters) abort
 	let s:dockertools_ls_filter = l:filters
 endfunction
 
+function! s:dt_set_format(manager) abort
+	if !exists('g:dockertools_'.a:manager.'_format')
+		return ''
+	endif
+	return shellescape(printf('--format=%s', eval('g:dockertools_'.a:manager.'_format')), 1)
+endfunction
+
 function! s:dt_do(manager,action,id,...) abort
 	let l:config = s:dt_load_config(a:manager,a:action)
 	if has_key(l:config,'options')
@@ -234,6 +242,7 @@ function! s:dt_do(manager,action,id,...) abort
 	if has_key(l:config,'args')
 		let l:runner.args = l:config.args
 	endif
+
 	let l:runner.Fn = funcref('s:'.l:config['mode'].'_mode')
 	let l:runner.Do = funcref('s:'.l:config['type'].'_type')
 	if has_key(l:config,'msg')

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -100,7 +100,7 @@ COMMANDS                                               *docker-tools-commands*
 	  Show container logs.
 
 ==============================================================================
-MANAGERS                                                 *docker-tools-managers*
+MANAGERS                                               *docker-tools-managers*
 
 Manager is the implementation of docker's management commands. Currently 
 supports: 'list', 'container'.
@@ -169,7 +169,7 @@ Show all or running containers only by default. Default value: 1
   let g:dockertools_default_all = 1
 <
 
-                                                      *'g:dockertools_managers'*
+                                                    *'g:dockertools_managers'*
 
 Use this option to set the supported managers and its order. 
 Default value: ['container', 'image', 'network']
@@ -203,6 +203,29 @@ Default value: 0
 <
 Note: |system()| will not return callback message.
 
+                                            *'g:dockertools_container_format'*
+
+Format display output for containers. Please refer to
+https://docs.docker.com/config/formatting/ for more details.
+>
+	let g:dockertools_container_format = 'table {{.ID}}\t{{.Name}}'
+<
+
+                                                *'g:dockertools_image_format'*
+
+Format display output for images. Please refer to
+https://docs.docker.com/config/formatting/ for more details.
+>
+	let g:dockertools_image_format = 'table {{.Repository}}\t{{.Tag}}'
+<
+
+                                              *'g:dockertools_network_format'*
+
+Format display output for networks. Please refer to
+https://docs.docker.com/config/formatting/ for more details.
+>
+	let g:dockertools_network_format = 'table {{.ID}}\t{{.Name}}'
+<
 
                                                  *'g:dockertools_docker_host'*
 

--- a/plugin/vim-docker-tools.vim
+++ b/plugin/vim-docker-tools.vim
@@ -46,6 +46,18 @@ if !exists('g:dockertools_disable_job')
 	let g:dockertools_disable_job = 0
 endif
 
+if !exists('g:dockertools_container_format')
+	let g:dockertools_container_format = 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}'
+endif
+
+if !exists('g:dockertools_image_format')
+	let g:dockertools_image_format = 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}'
+endif
+
+if !exists('g:dockertools_network_format')
+	let g:dockertools_network_format = 'table {{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.Scope}}'
+endif
+
 if exists('g:dockertools_docker_host')
 	call s:dt_set_host(g:dockertools_docker_host)
 else


### PR DESCRIPTION
Adding 3 options for formatting output: `g:dockertools_container_format`, `g:dockertools_image_format`, `g:dockertools_network_format`.