### PR TITLE
Format Readme to support Github copy button on code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,28 @@
 * Support container commands (and more in the future!). For details please check out the documentation (`:help docker-tools-commands`).
 * Autocompletion for commands
 * Full documentation in `:help vim-docker-tools`
+
 # Install
 * Pathogen
-  * `git clone https://github.com/kkvh/vim-docker-tools.git ~/.vim/bundle/vim-docker-tools`
+
+      git clone https://github.com/kkvh/vim-docker-tools.git ~/.vim/bundle/vim-docker-tools
+
 * Vim-plug
-  * `Plug 'kkvh/vim-docker-tools'`
+
+      Plug 'kkvh/vim-docker-tools'
+
 * NeoBundle
-  * `NeoBundle 'kkvh/vim-docker-tools'`
+
+      `NeoBundle 'kkvh/vim-docker-tools'
+
 * Vundle
-  * `Plugin 'kkvh/vim-docker-tools'`
+
+      Plugin 'kkvh/vim-docker-tools'
+
 * Manual
-  * Copy all of the files into your `~/.vim` directory
+
+      # Copy all of the files into your `~/.vim` directory
+
 # Roadmap
 * [x] Refactor docker runner structure
 * [x] Refactor key mapping
@@ -29,5 +40,6 @@
 * Network functions
 * [x] Network command autocomplete
 * Dockerfile functions
+
 # Contributing
 Feel free to raise any questions/issues/comments. Submit pull request as you want.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 * NeoBundle
 
-      `NeoBundle 'kkvh/vim-docker-tools'
+      NeoBundle 'kkvh/vim-docker-tools'
 
 * Vundle
 


### PR DESCRIPTION
Because I find the copy overlay on a project's readme very convenient.